### PR TITLE
fix various php notices on plugin activation #1

### DIFF
--- a/inc/info_metabox.php
+++ b/inc/info_metabox.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 // Add "Accessibility at NC State metabox"
 
@@ -6,7 +6,7 @@ function ncsu_a11y_meta_box() {
 
     $ncsu_a11y_options = get_option( 'ncsu_a11y', array() );
 
-    if ( $ncsu_a11y_options['post_types'] ) {
+    if ( isset( $ncsu_a11y_options['post_types'] ) ) {
         $checked_post_types = $ncsu_a11y_options['post_types'];
     } else {
         $checked_post_types = get_post_types( array( 'public' => true ) );
@@ -17,6 +17,8 @@ function ncsu_a11y_meta_box() {
 add_action( 'add_meta_boxes', 'ncsu_a11y_meta_box' );
 
 function ncsu_a11y_meta_content() {
+
+    global $post;
 
     $default_meta_text = '<h3>' . __( 'What is Web Accessibility?', 'ncsu-a11y-helper' ) . '</h3>'
                          .'<p><a href="http://go.ncsu.edu/what-is-a11y">' . __( 'Web accessibility', 'ncsu-a11y-helper' ) . '</a> '

--- a/inc/publish_metabox.php
+++ b/inc/publish_metabox.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 // Add "Run Accessibility Scan" button to Publish metabox
 function ncsu_a11y_run_button($post) {
@@ -6,7 +6,7 @@ function ncsu_a11y_run_button($post) {
     $ncsu_a11y_options = get_option( 'ncsu_a11y', array() );
     $current_screen = get_current_screen()->id;
 
-    if ( $ncsu_a11y_options['post_types'] ) {
+    if ( isset( $ncsu_a11y_options['post_types'] ) ) {
         $checked_post_types = $ncsu_a11y_options['post_types'];
     } else {
         $checked_post_types = get_post_types( array( 'public' => true ) );
@@ -19,7 +19,7 @@ function ncsu_a11y_run_button($post) {
             'Run Accessibility Check<span class="screen-reader-text"> (opens in a new window)</span>',
             'Learn more about accessibility'
             );
-        
+
     }
 
 }

--- a/ncsu-a11y-helper.php
+++ b/ncsu-a11y-helper.php
@@ -10,8 +10,8 @@
  *
  */
 
-define( __NCSU_A11Y_HELPER_PATH__, plugin_dir_path(__FILE__) );
-define( __NCSU_A11Y_HELPER_URL__, plugins_url(__FILE__) );
+define( '__NCSU_A11Y_HELPER_PATH__', plugin_dir_path(__FILE__) );
+define( '__NCSU_A11Y_HELPER_URL__', plugins_url(__FILE__) );
 
 // Misc useful functions
 require_once( plugin_dir_path(__FILE__) . '/inc/misc.php' );
@@ -60,7 +60,7 @@ function ncsu_a11y_helper__scripts_front( $hook ) {
         $my_template = ( get_page_template_slug($post_id) ) ? preg_replace('/\\.[^.\\s]{3,4}$/', '', get_page_template_slug($post_id) ) : 'page' ;
 
         $my_wrapper = ( $ncsu_a11y_options[str_replace( '-', '_', $my_template )] ) ? $ncsu_a11y_options[str_replace( '-', '_', $my_template )] : '.type-page';
-        
+
     } else {
         $my_wrapper = ( $ncsu_a11y_options[$post_type] ) ? $ncsu_a11y_options[$post_type] : '.' . $post_type;
     }
@@ -93,7 +93,7 @@ function ncsu_a11y_helper__scripts_front( $hook ) {
         wp_enqueue_style( 'a11y_styles' );
 
     }
-        
+
 }
 add_action( 'wp_enqueue_scripts', 'ncsu_a11y_helper__scripts_front' );
 


### PR DESCRIPTION
Main fix for plugin activation error notice while WP_DEBUG is enabled:
* Notice: Use of undefined constant __NCSU_A11Y_HELPER_PATH__ - assumed '__NCSU_A11Y_HELPER_PATH__'.
* Notice: Use of undefined constant __NCSU_A11Y_HELPER_URL__ - assumed '__NCSU_A11Y_HELPER_URL__'.

Commit also includes a few fixes for the following PHP notices while giving plugin a spin on the default editor (post_types index does not exist in array before plugin options are saved for first time):
* Notice: Undefined index: post_types in /app/public/wp-content/plugins/ncsu-a11y-helper/inc/info_metabox.php on line 9
* Notice: Undefined variable: post in /app/public/wp-content/plugins/ncsu-a11y-helper/inc/info_metabox.php on line 26
Notice: Undefined index: post_types in /app/public/wp-content/plugins/ncsu-a11y-helper/inc/publish_metabox.php on line 9